### PR TITLE
refactor

### DIFF
--- a/common/mutex.go
+++ b/common/mutex.go
@@ -32,3 +32,8 @@ import (
 type RWMutex struct {
 	sync.RWMutex
 }
+
+// Mutex is a wrapper around sync.Mutex
+type Mutex struct {
+	sync.Mutex
+}


### PR DESCRIPTION
I've redesigned the abstraction for nsm probe, now it works well and is easier to maintain.
### Data Structure
The general idea is that, we can't bypass two types of mappings:
- we need a mapping from inode to connections, it is crucial in graph event calls.
- we need a mapping from remoteConnectionId(I call it bridgeID) to crossConnects, it is crucial in matching two crossConnects.

Therefore, I redesign the data structure in probe. Now, a probe has two mappings, the first one, `iNodeConnectionPool`, is a mapping from `inode`(int64) to `iNodeBuffer`, the second one `remoteLookUpTable`, is a mapping from `bridgeID` to `lookUpTableElement`.
The second mapping is easy to understand, I'll tell some more details about `iNodeConnectionPool`'s value`iNodeBuffer` :
Each `iNodeBuffer` has a bool, denotes whether the netnsInode is available, and a mapping from `crossConnectID` to `connection`s.
``` go
type iNodeBuffer struct {
	inodeAvail bool
	connections map[string]connection
}
``` 
`connection` is an interface, with two possible types, either `localConnectionPair` or `remoteConnectionPair`.
``` go
type connection interface {
	onEventDelete(*graph.Graph)
	onEventUpdate(*graph.Graph)
}

// baseConnectionPair base class of connections
type baseConnectionPair struct {
	payload  string
	srcInode int64
	dstInode int64
	src      *localconn.Connection
	dst      *localconn.Connection
}

type localConnectionPair struct {
	baseConnectionPair
	ID string
}

type remoteConnectionPair struct {
	baseConnectionPair
	bridge *remoteconn.Connection
	srcID  string
	dstID  string
}
```
### Functions
`connection` has two methods that deal with either update events or delete events. They could be invoked from two functions:
- Function calls when an Inode appear/disapeear on the graph. Under such a situation, those two methods would be applied to each connection stored in the corresponding `iNodeBuffer`
- Function calls when a `ConnectionEvent` is acquired by the probe. Under such a situation, if both netnsInode are available, then those two methods would be applied to corresponding `connection`.

Note that under the first situation, if the connection is a remote connection, then a pair exists doesn't mean it is complete, because at that time maybe only half of the crossConnect pairs is stored. So in those two methods for `remoteConnectionPair`, a check for completeness is required. For `localConnectionPair`, the pair exists should mean that the information is complete.
Function calls when a local `ConnectionEvent` is acquired by the probe is straightforward, now consider what will happen when a remote `ConnectionEvent` is acquired.
event type UPDATE:
the probe will look up in `remoteLookUpTable`. 
- If the key doesn't exist, that means the crossConnect is the first one. It will create a `remoteConnectionPair` and store the pair in its `iNodeBuffer`, and store the corresponding `crossConnectID` and `inode` in `remoteLookUpTable`.
- If the key exists, that means the crossConnect is the second one. It will get the `remoteConnectionPair`, then fill the with its information, and store a shallow copy of the pair in its own `iNodeBuffer`, then call the function to update the graph.

event type DELETE:
the probe will directly delete the connection, then try to modify the graph and delete its own information from the `remoteConnectionPair`. Only the first try to modify the graph will succeed, since for the second time, the function would find that the pair is incomplete and directly return, when both connection is removed from both `iNodeBuffer`, the pair should be automatically released since there is no more reference to it.
### Thread Safety
- graph
Writing to the graph should be taken care of across different probes. I've successfully abstract all of those accesses in methods for `connection` interface. Nowhere but those functions should lock the graph.
- probe
Writing to the probe should be taken care of across different goroutines that deal with different nsmds. I think all of the calls are writers, so I use a Mutex instead of a RWMutex. A graph access should be executed in a probe access to avoid dead locks.

In the previous version, the `addCrossConnToGraph()` function call would cause a dead lock. The reason is that [graph is locked when calling a event handler](https://github.com/Orange-OpenSource/skydive/blob/nsm/topology/graph/graph.go#L221). So in those methods, I start another goroutine to execute the graph update.